### PR TITLE
Fix: Robust handling of entity positions in PhysicsManager

### DIFF
--- a/src/engine/physicsManager.js
+++ b/src/engine/physicsManager.js
@@ -171,13 +171,21 @@ export default class PhysicsManager {
             const position = rigidBody.translation();
             const rotation = rigidBody.rotation();
 
-            // Ensure entity has a proper Vector3 position
-            if (!entity.position || typeof entity.position.set !== 'function') {
-                console.warn('PhysicsManager: Entity missing proper Vector3 position, creating one:', entity);
-                entity.position = new THREE.Vector3();
+            // Ensure entity.position is a THREE.Vector3, converting if necessary
+            const currentEntityPosition = entity.position;
+            if (!currentEntityPosition || typeof currentEntityPosition.set !== 'function') {
+                const entityIdentifier = entity.name || entity.type || 'Unnamed Entity';
+                console.warn(`PhysicsManager: Entity '${entityIdentifier}' position is not a THREE.Vector3. Converting now.`);
+
+                // Preserve original x,y,z values if they exist on the plain object
+                const px = currentEntityPosition ? (currentEntityPosition.x || 0) : 0;
+                const py = currentEntityPosition ? (currentEntityPosition.y || 0) : 0;
+                const pz = currentEntityPosition ? (currentEntityPosition.z || 0) : 0;
+                entity.position = new THREE.Vector3(px, py, pz);
             }
 
-            // Update entity position (Vector3)
+            // Now, entity.position is guaranteed to be a THREE.Vector3.
+            // Update entity position from the physics simulation (using 'position' from rigidBody.translation())
             entity.position.set(position.x, position.y, position.z);
 
             // Update entity rotation if it has one


### PR DESCRIPTION
Previously, if an entity was processed by PhysicsManager.update() and its .position property was not a THREE.Vector3 instance, PhysicsManager would replace entity.position with a new THREE.Vector3(0,0,0) before updating it from the physics state. This could lead to a brief state where the entity's position was incorrectly (0,0,0) and could cause issues if other code accessed the position object by reference, as the reference would change.

This commit modifies PhysicsManager.update() to:
1.  Log a more informative warning when an entity's position is not a THREE.Vector3, including the entity's name or type.
2.  Convert the existing entity.position to a THREE.Vector3 while preserving its original x, y, and z coordinates, if they exist. This avoids the temporary reset to (0,0,0).

This change makes the physics integration more robust, especially for entities that might be dynamically created with plain object positions (e.g., in test harnesses or potentially by plugins).