### PR TITLE
Fix: Update Rapier physics initialization to use object parameter

### DIFF
--- a/src/engine/physicsManager.js
+++ b/src/engine/physicsManager.js
@@ -22,9 +22,9 @@ export default class PhysicsManager {
             
             // Use modern Rapier initialization API
             if (typeof this.RAPIER.init === 'function') {
-                await this.RAPIER.init();
+                await this.RAPIER.init({});
             } else if (typeof this.RAPIER.default?.init === 'function') {
-                await this.RAPIER.default.init();
+                await this.RAPIER.default.init({});
             }
             
             // Create physics world without gravity (space environment)
@@ -40,9 +40,9 @@ export default class PhysicsManager {
                 
                 // Use modern Rapier initialization API
                 if (typeof this.RAPIER.init === 'function') {
-                    await this.RAPIER.init();
+                    await this.RAPIER.init({});
                 } else if (typeof this.RAPIER.default?.init === 'function') {
-                    await this.RAPIER.default.init();
+                    await this.RAPIER.default.init({});
                 }
                 
                 const gravity = { x: 0.0, y: 0.0, z: 0.0 };


### PR DESCRIPTION
The Rapier physics engine's `init()` function was being called without arguments. Newer versions of Rapier show a deprecation warning for this, recommending passing a single object as a parameter.

This commit updates all calls to `RAPIER.init()` and `RAPIER.default.init()` within `PhysicsManager` to pass an empty object `{}`. This change addresses the deprecation warning by using the recommended object parameter format, while presumably allowing Rapier to continue using its default mechanism for locating the WASM module.

This affects initialization from both CDN and npm package sources.